### PR TITLE
Clarify 2 byte color encoding

### DIFF
--- a/spec/iconvg-spec.md
+++ b/spec/iconvg-spec.md
@@ -141,7 +141,9 @@ that byte value such that `0`, `1`, `2`, `3` and `4` map to `0x00`, `0x40`,
 register (with `CREG` indexed by that byte value minus `192`).
 
 For a *2 byte encoding*, the red, green, blue and alpha values are all 4 bit
-values. For example, the color `33:88:00:FF` can be encoded as `0x38 0x0F`.
+values which are extended to 8 bits by duplicating each nibble (or equivalently,
+they are 4 bit color values interpolated to an 8 bit color space). For example,
+the color `33:88:00:FF` can be encoded as `0x38 0x0F`.
 
 For a *3 byte direct encoding*, the red, green and blue values are all 8 bit
 values. The alpha value is implicitly 255. For example, the color `30:66:07:FF`


### PR DESCRIPTION
From the example I believe this is what was intended? A literal interpretation of the original text could be interpreted as saying the color values literally are just 4 bits per channel, but in 8 bit color space, so the brightest you can generate in each channel is 0x0F, which doesn't match the example.
